### PR TITLE
Add custom tables, remove error on empty commit

### DIFF
--- a/dstore_test.go
+++ b/dstore_test.go
@@ -19,8 +19,7 @@ import (
 
 func TestAutoBatching(t *testing.T) {
 	opts := &Options{
-		Table:    "testauto",
-		Password: "simple",
+		Table: "testauto",
 	}
 	store, err := opts.CreatePostgres()
 	if err != nil {
@@ -123,8 +122,7 @@ func TestProviderManagerDatastore(t *testing.T) {
 	defer cancel()
 
 	opts := &Options{
-		Table:    "providertest",
-		Password: "simple",
+		Table: "providertest",
 	}
 	store, err := opts.CreatePostgres()
 	if err != nil {

--- a/dstore_test.go
+++ b/dstore_test.go
@@ -1,0 +1,158 @@
+package sqlds
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/autobatch"
+	"github.com/libp2p/go-libp2p-kad-dht/providers"
+
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	cid "github.com/ipfs/go-cid"
+	u "github.com/ipfs/go-ipfs-util"
+)
+
+func TestAutoBatching(t *testing.T) {
+	opts := &Options{
+		Table:    "testauto",
+		Password: "simple",
+	}
+	store, err := opts.CreatePostgres()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	batchSize := 16
+
+	d := autobatch.NewAutoBatching(store, batchSize)
+
+	// bch, err := store.Batch()
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+
+	var keys []datastore.Key
+	value := []byte("hello world!")
+	for i := 0; i < batchSize; i++ {
+		key := datastore.NewKey(fmt.Sprintf("key%d", i))
+		keys = append(keys, key)
+	}
+	for _, k := range keys {
+		err := d.Put(k, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Get works normally.
+	for _, k := range keys {
+		val, err := d.Get(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(val, value) {
+			t.Fatal("wrong value")
+		}
+	}
+
+	// Not flushed
+	_, err = store.Get(keys[0])
+	if err != datastore.ErrNotFound {
+		t.Fatal("shouldnt have found value")
+	}
+
+	// Delete works.
+	err = d.Delete(keys[14])
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = d.Get(keys[14])
+	if err != datastore.ErrNotFound {
+		t.Fatal(err)
+	}
+
+	// Still not flushed
+	_, err = store.Get(keys[0])
+	if err != datastore.ErrNotFound {
+		t.Fatal("shouldnt have found value")
+	}
+
+	// Final put flushes.
+	err = d.Put(datastore.NewKey("test16"), value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// should be flushed now, try to get keys from child datastore
+	for _, k := range keys[:14] {
+		val, err := store.Get(k)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(val, value) {
+			t.Fatal("wrong value")
+		}
+	}
+
+	// Never flushed the deleted key.
+	_, err = store.Get(keys[14])
+	if err != datastore.ErrNotFound {
+		t.Fatal("shouldnt have found value")
+	}
+
+	// Delete doesn't flush
+	err = d.Delete(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := store.Get(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(val, value) {
+		t.Fatal("wrong value")
+	}
+}
+
+func TestProviderManagerDatastore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := &Options{
+		Table:    "providertest",
+		Password: "simple",
+	}
+	store, err := opts.CreatePostgres()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mid := peer.ID("testing")
+	p := providers.NewProviderManager(ctx, mid, dssync.MutexWrap(store))
+	a := cid.NewCidV0(u.Hash([]byte("test")))
+	p.AddProvider(ctx, a, peer.ID("testingprovider"))
+
+	// Not cached
+	resp := p.GetProviders(ctx, a)
+	if len(resp) != 1 {
+		t.Fatal("Could not retrieve provider.")
+	}
+
+	// Cached
+	resp = p.GetProviders(ctx, a)
+	if len(resp) != 1 {
+		t.Fatal("Could not retrieve provider.")
+	}
+
+	p.Process().Close()
+
+}

--- a/dstore_test.go
+++ b/dstore_test.go
@@ -31,11 +31,6 @@ func TestAutoBatching(t *testing.T) {
 
 	d := autobatch.NewAutoBatching(store, batchSize)
 
-	// bch, err := store.Batch()
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-
 	var keys []datastore.Key
 	value := []byte("hello world!")
 	for i := 0; i < batchSize; i++ {

--- a/dstore_test.go
+++ b/dstore_test.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"testing"
 
+	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/autobatch"
-	"github.com/libp2p/go-libp2p-kad-dht/providers"
-
 	dssync "github.com/ipfs/go-datastore/sync"
-	"github.com/libp2p/go-libp2p-core/peer"
-
-	cid "github.com/ipfs/go-cid"
 	u "github.com/ipfs/go-ipfs-util"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-kad-dht/providers"
 )
 
 func TestAutoBatching(t *testing.T) {

--- a/sql_kv_ds.go
+++ b/sql_kv_ds.go
@@ -1,0 +1,103 @@
+package sqlds
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq" //postgres driver
+)
+
+// Options are the postgres datastore options, reexported here for convenience.
+type Options struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	Database string
+	Table    string
+}
+
+type queries struct {
+	tableName string
+}
+
+func newQueries(tableName string) *queries {
+	return &queries{tableName}
+}
+
+func (q queries) Delete() string {
+	return `DELETE FROM ` + q.tableName + ` WHERE key = $1`
+}
+
+func (q queries) Exists() string {
+	return `SELECT exists(SELECT 1 FROM ` + q.tableName + ` WHERE key=$1)`
+}
+
+func (q queries) Get() string {
+	return `SELECT data FROM ` + q.tableName + ` WHERE key = $1`
+}
+
+func (q queries) Put() string {
+	return `INSERT INTO ` + q.tableName + ` (key, data) SELECT $1, $2 WHERE NOT EXISTS ( SELECT key FROM ` + q.tableName + ` WHERE key = $1)`
+}
+
+func (q queries) Query() string {
+	return `SELECT key, data FROM ` + q.tableName
+}
+
+func (q queries) Prefix() string {
+	return ` WHERE key LIKE '%s%%' ORDER BY key`
+}
+
+func (q queries) Limit() string {
+	return ` LIMIT %d`
+}
+
+func (q queries) Offset() string {
+	return ` OFFSET %d`
+}
+
+func (q queries) GetSize() string {
+	return `SELECT octet_length(data) FROM ` + q.tableName + ` WHERE key = $1`
+}
+
+// Create returns a datastore connected to postgres initialized with a table
+func (opts *Options) CreatePostgres() (*Datastore, error) {
+	opts.setDefaults()
+	fmtstr := "postgresql:///%s?host=%s&port=%s&user=%s&password=%s&sslmode=disable"
+	constr := fmt.Sprintf(fmtstr, opts.Database, opts.Host, opts.Port, opts.User, opts.Password)
+	db, err := sql.Open("postgres", constr)
+	if err != nil {
+		return nil, err
+	}
+
+	createTable := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (key TEXT NOT NULL UNIQUE, data BYTEA NOT NULL)", opts.Table)
+	_, err = db.Exec(createTable)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDatastore(db, newQueries(opts.Table)), nil
+}
+
+func (opts *Options) setDefaults() {
+	if opts.Table == "" {
+		opts.Table = "kv"
+	}
+	if opts.Host == "" {
+		opts.Host = "postgres"
+	}
+
+	if opts.Port == "" {
+		opts.Port = "5432"
+	}
+
+	if opts.User == "" {
+		opts.User = "postgres"
+	}
+
+	if opts.Database == "" {
+		opts.Database = "datastore"
+	}
+}

--- a/sql_kv_ds.go
+++ b/sql_kv_ds.go
@@ -21,7 +21,7 @@ type queries struct {
 	tableName string
 }
 
-func newQueries(tableName string) *queries {
+func NewQueriesForTable(tableName string) *queries {
 	return &queries{tableName}
 }
 
@@ -78,7 +78,7 @@ func (opts *Options) CreatePostgres() (*Datastore, error) {
 		return nil, err
 	}
 
-	return NewDatastore(db, newQueries(opts.Table)), nil
+	return NewDatastore(db, NewQueriesForTable(opts.Table)), nil
 }
 
 func (opts *Options) setDefaults() {


### PR DESCRIPTION
This commit adds a postgres datastore that additionally creates tables if they
do not exist.

This commit also removes returning an error on empty Commit() to work nicely
with garbage collection that periodically flushes ds.Batch.