### PR TITLE
fix: Addressed issues will nil pointer exceptions

### DIFF
--- a/dstore.go
+++ b/dstore.go
@@ -67,7 +67,9 @@ func (b *batch) Put(key ds.Key, val []byte) error {
 
 	txn, err := b.GetTransaction()
 	if err != nil {
-		b.txn.Rollback()
+		if b.txn != nil {
+			b.txn.Rollback()
+		}
 		return err
 	}
 
@@ -83,7 +85,10 @@ func (b *batch) Put(key ds.Key, val []byte) error {
 func (b *batch) Delete(key ds.Key) error {
 	txn, err := b.GetTransaction()
 	if err != nil {
-		b.txn.Rollback()
+		if b.txn != nil {
+			b.txn.Rollback()
+		}
+		return err
 	}
 
 	_, err = txn.Exec(b.queries.Delete(), key.String())

--- a/dstore.go
+++ b/dstore.go
@@ -60,21 +60,24 @@ func (b *batch) GetTransaction() (*sql.Tx, error) {
 	return newTransaction, nil
 }
 
+func (b *batch) rollbackTxn(errPtr *error) {
+	err := *errPtr
+	if err != nil {
+		if b.txn != nil {
+			b.txn.Rollback()
+		}
+	}
+	if r := recover(); r != nil {
+		if b.txn != nil {
+			b.txn.Rollback()
+		}
+		// Re-panic so that callers can potentially handle it.
+		panic(r)
+	}
+}
+
 func (b *batch) Put(key ds.Key, val []byte) (err error) {
-	defer func() {
-		if err != nil {
-			if b.txn != nil {
-				b.txn.Rollback()
-			}
-		}
-		if r := recover(); r != nil {
-			if b.txn != nil {
-				b.txn.Rollback()
-			}
-			// Re-panic so that callers can potentially handle it.
-			panic(r)
-		}
-	}()
+	defer b.rollbackTxn(&err)
 
 	if val == nil {
 		return ErrInvalidType
@@ -94,20 +97,7 @@ func (b *batch) Put(key ds.Key, val []byte) (err error) {
 }
 
 func (b *batch) Delete(key ds.Key) (err error) {
-	defer func() {
-		if err != nil {
-			if b.txn != nil {
-				b.txn.Rollback()
-			}
-		}
-		if r := recover(); r != nil {
-			if b.txn != nil {
-				b.txn.Rollback()
-			}
-			// Re-panic so that callers can potentially handle it.
-			panic(r)
-		}
-	}()
+	defer b.rollbackTxn(&err)
 
 	txn, err := b.GetTransaction()
 	if err != nil {


### PR DESCRIPTION
Previously, `Put` and `Delete` could panic if the database was already closed as `b.txn` would be `nil`. This PR addresses these issues, which will allow this key-value store to be used in [Mesh's codebase](https://github.com/0xProject/0x-mesh).